### PR TITLE
fix id

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,4 +1,4 @@
-id = "catppuccin-themes"
+id = "catppuccin"
 name = "Catppuccin Themes"
 schema_version = 1
 version = "0.2.6"


### PR DESCRIPTION
zed `extension.toml` needs `id` value to be the same as `zed-extension/extensions.toml` 