### PR TITLE
fix(syntax): adjust namespace

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "catppuccin"
 name = "Catppuccin Themes"
 schema_version = 1
-version = "0.2.15"
+version = "0.2.16"
 authors = ["Andrew Tec <andrewtec@enjoi.dev>"]
 description = "🦀 Soothing pastel theme for Zed"
 repository = "https://github.com/catppuccin/zed"

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -546,7 +546,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#7287fd",
+                        "color": "#df8e1d",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -1196,7 +1196,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#babbf1",
+                        "color": "#e5c890",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -1846,7 +1846,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#b7bdf8",
+                        "color": "#eed49f",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -2496,7 +2496,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#b4befe",
+                        "color": "#f9e2af",
                         "font_style": "italic",
                         "font_weight": null
                     },

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -546,7 +546,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#7287fd",
+                        "color": "#df8e1d",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1196,7 +1196,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#babbf1",
+                        "color": "#e5c890",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1846,7 +1846,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#b7bdf8",
+                        "color": "#eed49f",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -2496,7 +2496,7 @@
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#b4befe",
+                        "color": "#f9e2af",
                         "font_style": null,
                         "font_weight": null
                     },

--- a/zed.tera
+++ b/zed.tera
@@ -561,7 +561,7 @@ whiskers:
                         "font_weight": null
                     },
                     "namespace": {
-                        "color": "#{{ c.lavender.hex }}",
+                        "color": "#{{ c.yellow.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null
                     },


### PR DESCRIPTION
fix `namespace`: should be yellow

before:
<img width="903" alt="image" src="https://github.com/user-attachments/assets/99fa0a16-7124-43eb-a470-791d60157536">

after:
<img width="932" alt="image" src="https://github.com/user-attachments/assets/443d2abe-9239-47e9-87dd-31c5fd429443">

