### PR TITLE
feat: define "accents" for indent_aware coloring

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -6,8 +6,16 @@
         {
             "name": "Catppuccin Latte",
             "appearance": "light",
+            "accents": [
+                "#823556ff",
+                "#87684bff",
+                "#486f50ff",
+                "#37697cff",
+                "#3a58a1ff",
+                "#64469fff",
+                "#3b6f87ff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
                 "border.variant": "#9658eb",
@@ -154,24 +162,9 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#3b6f87",
-                        "selection": "#3b6f8733",
-                        "background": "#3b6f87"
-                    },
-                    {
                         "cursor": "#823556",
                         "selection": "#82355633",
                         "background": "#823556"
-                    },
-                    {
-                        "cursor": "#37697c",
-                        "selection": "#37697c33",
-                        "background": "#37697c"
-                    },
-                    {
-                        "cursor": "#945743",
-                        "selection": "#94574333",
-                        "background": "#945743"
                     },
                     {
                         "cursor": "#87684b",
@@ -179,14 +172,29 @@
                         "background": "#87684b"
                     },
                     {
+                        "cursor": "#486f50",
+                        "selection": "#486f5033",
+                        "background": "#486f50"
+                    },
+                    {
+                        "cursor": "#37697c",
+                        "selection": "#37697c33",
+                        "background": "#37697c"
+                    },
+                    {
                         "cursor": "#3a58a1",
                         "selection": "#3a58a133",
                         "background": "#3a58a1"
                     },
                     {
-                        "cursor": "#486f50",
-                        "selection": "#486f5033",
-                        "background": "#486f50"
+                        "cursor": "#64469f",
+                        "selection": "#64469f33",
+                        "background": "#64469f"
+                    },
+                    {
+                        "cursor": "#3b6f87",
+                        "selection": "#3b6f8733",
+                        "background": "#3b6f87"
                     }
                 ],
                 "syntax": {
@@ -691,8 +699,16 @@
         {
             "name": "Catppuccin Frappé",
             "appearance": "dark",
+            "accents": [
+                "#d3b1c8ff",
+                "#d3cdcdff",
+                "#b9d1caff",
+                "#abcddfff",
+                "#afc1f2ff",
+                "#c8bcefff",
+                "#accaebff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#414559",
                 "border.variant": "#af8cca",
@@ -839,24 +855,9 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#accaeb",
-                        "selection": "#accaeb33",
-                        "background": "#accaeb"
-                    },
-                    {
                         "cursor": "#d3b1c8",
                         "selection": "#d3b1c833",
                         "background": "#d3b1c8"
-                    },
-                    {
-                        "cursor": "#abcddf",
-                        "selection": "#abcddf33",
-                        "background": "#abcddf"
-                    },
-                    {
-                        "cursor": "#d7bdc2",
-                        "selection": "#d7bdc233",
-                        "background": "#d7bdc2"
                     },
                     {
                         "cursor": "#d3cdcd",
@@ -864,14 +865,29 @@
                         "background": "#d3cdcd"
                     },
                     {
+                        "cursor": "#b9d1ca",
+                        "selection": "#b9d1ca33",
+                        "background": "#b9d1ca"
+                    },
+                    {
+                        "cursor": "#abcddf",
+                        "selection": "#abcddf33",
+                        "background": "#abcddf"
+                    },
+                    {
                         "cursor": "#afc1f2",
                         "selection": "#afc1f233",
                         "background": "#afc1f2"
                     },
                     {
-                        "cursor": "#b9d1ca",
-                        "selection": "#b9d1ca33",
-                        "background": "#b9d1ca"
+                        "cursor": "#c8bcef",
+                        "selection": "#c8bcef33",
+                        "background": "#c8bcef"
+                    },
+                    {
+                        "cursor": "#accaeb",
+                        "selection": "#accaeb33",
+                        "background": "#accaeb"
                     }
                 ],
                 "syntax": {
@@ -1376,8 +1392,16 @@
         {
             "name": "Catppuccin Macchiato",
             "appearance": "dark",
+            "accents": [
+                "#d8b5cfff",
+                "#d8d4d3ff",
+                "#bbd6cfff",
+                "#b1d4e4ff",
+                "#b0c4f5ff",
+                "#c8bff5ff",
+                "#abcdeeff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
                 "border.variant": "#a98cd5",
@@ -1524,24 +1548,9 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#abcdee",
-                        "selection": "#abcdee33",
-                        "background": "#abcdee"
-                    },
-                    {
                         "cursor": "#d8b5cf",
                         "selection": "#d8b5cf33",
                         "background": "#d8b5cf"
-                    },
-                    {
-                        "cursor": "#b1d4e4",
-                        "selection": "#b1d4e433",
-                        "background": "#b1d4e4"
-                    },
-                    {
-                        "cursor": "#dbc3c6",
-                        "selection": "#dbc3c633",
-                        "background": "#dbc3c6"
                     },
                     {
                         "cursor": "#d8d4d3",
@@ -1549,14 +1558,29 @@
                         "background": "#d8d4d3"
                     },
                     {
+                        "cursor": "#bbd6cf",
+                        "selection": "#bbd6cf33",
+                        "background": "#bbd6cf"
+                    },
+                    {
+                        "cursor": "#b1d4e4",
+                        "selection": "#b1d4e433",
+                        "background": "#b1d4e4"
+                    },
+                    {
                         "cursor": "#b0c4f5",
                         "selection": "#b0c4f533",
                         "background": "#b0c4f5"
                     },
                     {
-                        "cursor": "#bbd6cf",
-                        "selection": "#bbd6cf33",
-                        "background": "#bbd6cf"
+                        "cursor": "#c8bff5",
+                        "selection": "#c8bff533",
+                        "background": "#c8bff5"
+                    },
+                    {
+                        "cursor": "#abcdee",
+                        "selection": "#abcdee33",
+                        "background": "#abcdee"
                     }
                 ],
                 "syntax": {
@@ -2061,8 +2085,16 @@
         {
             "name": "Catppuccin Mocha",
             "appearance": "dark",
+            "accents": [
+                "#dcb8d5ff",
+                "#dfdad8ff",
+                "#bddbd2ff",
+                "#b6dae7ff",
+                "#b2c8f6ff",
+                "#ccc2f5ff",
+                "#a9d0f0ff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#313244",
                 "border.variant": "#ac8fd4",
@@ -2209,24 +2241,9 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#a9d0f0",
-                        "selection": "#a9d0f033",
-                        "background": "#a9d0f0"
-                    },
-                    {
                         "cursor": "#dcb8d5",
                         "selection": "#dcb8d533",
                         "background": "#dcb8d5"
-                    },
-                    {
-                        "cursor": "#b6dae7",
-                        "selection": "#b6dae733",
-                        "background": "#b6dae7"
-                    },
-                    {
-                        "cursor": "#dfc8c8",
-                        "selection": "#dfc8c833",
-                        "background": "#dfc8c8"
                     },
                     {
                         "cursor": "#dfdad8",
@@ -2234,14 +2251,29 @@
                         "background": "#dfdad8"
                     },
                     {
+                        "cursor": "#bddbd2",
+                        "selection": "#bddbd233",
+                        "background": "#bddbd2"
+                    },
+                    {
+                        "cursor": "#b6dae7",
+                        "selection": "#b6dae733",
+                        "background": "#b6dae7"
+                    },
+                    {
                         "cursor": "#b2c8f6",
                         "selection": "#b2c8f633",
                         "background": "#b2c8f6"
                     },
                     {
-                        "cursor": "#bddbd2",
-                        "selection": "#bddbd233",
-                        "background": "#bddbd2"
+                        "cursor": "#ccc2f5",
+                        "selection": "#ccc2f533",
+                        "background": "#ccc2f5"
+                    },
+                    {
+                        "cursor": "#a9d0f0",
+                        "selection": "#a9d0f033",
+                        "background": "#a9d0f0"
                     }
                 ],
                 "syntax": {

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -6,16 +6,16 @@
         {
             "name": "Catppuccin Latte",
             "appearance": "light",
-            "accents": [
-                "#823556ff",
-                "#87684bff",
-                "#486f50ff",
-                "#37697cff",
-                "#3a58a1ff",
-                "#64469fff",
-                "#3b6f87ff"
-            ],
             "style": {
+                "accents": [
+                    "#823556ff",
+                    "#87684bff",
+                    "#486f50ff",
+                    "#37697cff",
+                    "#3a58a1ff",
+                    "#64469fff",
+                    "#3b6f87ff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
                 "border.variant": "#9658eb",
@@ -699,16 +699,16 @@
         {
             "name": "Catppuccin Frappé",
             "appearance": "dark",
-            "accents": [
-                "#d3b1c8ff",
-                "#d3cdcdff",
-                "#b9d1caff",
-                "#abcddfff",
-                "#afc1f2ff",
-                "#c8bcefff",
-                "#accaebff"
-            ],
             "style": {
+                "accents": [
+                    "#d3b1c8ff",
+                    "#d3cdcdff",
+                    "#b9d1caff",
+                    "#abcddfff",
+                    "#afc1f2ff",
+                    "#c8bcefff",
+                    "#accaebff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#414559",
                 "border.variant": "#af8cca",
@@ -1392,16 +1392,16 @@
         {
             "name": "Catppuccin Macchiato",
             "appearance": "dark",
-            "accents": [
-                "#d8b5cfff",
-                "#d8d4d3ff",
-                "#bbd6cfff",
-                "#b1d4e4ff",
-                "#b0c4f5ff",
-                "#c8bff5ff",
-                "#abcdeeff"
-            ],
             "style": {
+                "accents": [
+                    "#d8b5cfff",
+                    "#d8d4d3ff",
+                    "#bbd6cfff",
+                    "#b1d4e4ff",
+                    "#b0c4f5ff",
+                    "#c8bff5ff",
+                    "#abcdeeff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
                 "border.variant": "#a98cd5",
@@ -2085,16 +2085,16 @@
         {
             "name": "Catppuccin Mocha",
             "appearance": "dark",
-            "accents": [
-                "#dcb8d5ff",
-                "#dfdad8ff",
-                "#bddbd2ff",
-                "#b6dae7ff",
-                "#b2c8f6ff",
-                "#ccc2f5ff",
-                "#a9d0f0ff"
-            ],
             "style": {
+                "accents": [
+                    "#dcb8d5ff",
+                    "#dfdad8ff",
+                    "#bddbd2ff",
+                    "#b6dae7ff",
+                    "#b2c8f6ff",
+                    "#ccc2f5ff",
+                    "#a9d0f0ff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#313244",
                 "border.variant": "#ac8fd4",

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#823556ff",
-                    "#87684bff",
-                    "#486f50ff",
-                    "#37697cff",
-                    "#3a58a1ff",
-                    "#64469fff",
-                    "#3b6f87ff"
+                    "#b71c43ff",
+                    "#da601eff",
+                    "#c1822cff",
+                    "#429037ff",
+                    "#298fa6ff",
+                    "#6a7cdfff",
+                    "#7c3ed4ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -162,39 +162,39 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#823556",
-                        "selection": "#82355633",
-                        "background": "#823556"
+                        "cursor": "#b71c43",
+                        "selection": "#b71c4333",
+                        "background": "#b71c43"
                     },
                     {
-                        "cursor": "#87684b",
-                        "selection": "#87684b33",
-                        "background": "#87684b"
+                        "cursor": "#da601e",
+                        "selection": "#da601e33",
+                        "background": "#da601e"
                     },
                     {
-                        "cursor": "#486f50",
-                        "selection": "#486f5033",
-                        "background": "#486f50"
+                        "cursor": "#c1822c",
+                        "selection": "#c1822c33",
+                        "background": "#c1822c"
                     },
                     {
-                        "cursor": "#37697c",
-                        "selection": "#37697c33",
-                        "background": "#37697c"
+                        "cursor": "#429037",
+                        "selection": "#42903733",
+                        "background": "#429037"
                     },
                     {
-                        "cursor": "#3a58a1",
-                        "selection": "#3a58a133",
-                        "background": "#3a58a1"
+                        "cursor": "#298fa6",
+                        "selection": "#298fa633",
+                        "background": "#298fa6"
                     },
                     {
-                        "cursor": "#64469f",
-                        "selection": "#64469f33",
-                        "background": "#64469f"
+                        "cursor": "#6a7cdf",
+                        "selection": "#6a7cdf33",
+                        "background": "#6a7cdf"
                     },
                     {
-                        "cursor": "#3b6f87",
-                        "selection": "#3b6f8733",
-                        "background": "#3b6f87"
+                        "cursor": "#7c3ed4",
+                        "selection": "#7c3ed433",
+                        "background": "#7c3ed4"
                     }
                 ],
                 "syntax": {
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#d3b1c8ff",
-                    "#d3cdcdff",
-                    "#b9d1caff",
-                    "#abcddfff",
-                    "#afc1f2ff",
-                    "#c8bcefff",
-                    "#accaebff"
+                    "#e1929bff",
+                    "#e7a98fff",
+                    "#dfcaa4ff",
+                    "#add19fff",
+                    "#92c4e1ff",
+                    "#bdc0f2ff",
+                    "#caa8e9ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -855,39 +855,39 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#d3b1c8",
-                        "selection": "#d3b1c833",
-                        "background": "#d3b1c8"
+                        "cursor": "#e1929b",
+                        "selection": "#e1929b33",
+                        "background": "#e1929b"
                     },
                     {
-                        "cursor": "#d3cdcd",
-                        "selection": "#d3cdcd33",
-                        "background": "#d3cdcd"
+                        "cursor": "#e7a98f",
+                        "selection": "#e7a98f33",
+                        "background": "#e7a98f"
                     },
                     {
-                        "cursor": "#b9d1ca",
-                        "selection": "#b9d1ca33",
-                        "background": "#b9d1ca"
+                        "cursor": "#dfcaa4",
+                        "selection": "#dfcaa433",
+                        "background": "#dfcaa4"
                     },
                     {
-                        "cursor": "#abcddf",
-                        "selection": "#abcddf33",
-                        "background": "#abcddf"
+                        "cursor": "#add19f",
+                        "selection": "#add19f33",
+                        "background": "#add19f"
                     },
                     {
-                        "cursor": "#afc1f2",
-                        "selection": "#afc1f233",
-                        "background": "#afc1f2"
+                        "cursor": "#92c4e1",
+                        "selection": "#92c4e133",
+                        "background": "#92c4e1"
                     },
                     {
-                        "cursor": "#c8bcef",
-                        "selection": "#c8bcef33",
-                        "background": "#c8bcef"
+                        "cursor": "#bdc0f2",
+                        "selection": "#bdc0f233",
+                        "background": "#bdc0f2"
                     },
                     {
-                        "cursor": "#accaeb",
-                        "selection": "#accaeb33",
-                        "background": "#accaeb"
+                        "cursor": "#caa8e9",
+                        "selection": "#caa8e933",
+                        "background": "#caa8e9"
                     }
                 ],
                 "syntax": {
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#d8b5cfff",
-                    "#d8d4d3ff",
-                    "#bbd6cfff",
-                    "#b1d4e4ff",
-                    "#b0c4f5ff",
-                    "#c8bff5ff",
-                    "#abcdeeff"
+                    "#e696a9ff",
+                    "#ecb197ff",
+                    "#e6d4b0ff",
+                    "#add8a8ff",
+                    "#8cc7e7ff",
+                    "#bac1f7ff",
+                    "#c6aaf6ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -1548,39 +1548,39 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#d8b5cf",
-                        "selection": "#d8b5cf33",
-                        "background": "#d8b5cf"
+                        "cursor": "#e696a9",
+                        "selection": "#e696a933",
+                        "background": "#e696a9"
                     },
                     {
-                        "cursor": "#d8d4d3",
-                        "selection": "#d8d4d333",
-                        "background": "#d8d4d3"
+                        "cursor": "#ecb197",
+                        "selection": "#ecb19733",
+                        "background": "#ecb197"
                     },
                     {
-                        "cursor": "#bbd6cf",
-                        "selection": "#bbd6cf33",
-                        "background": "#bbd6cf"
+                        "cursor": "#e6d4b0",
+                        "selection": "#e6d4b033",
+                        "background": "#e6d4b0"
                     },
                     {
-                        "cursor": "#b1d4e4",
-                        "selection": "#b1d4e433",
-                        "background": "#b1d4e4"
+                        "cursor": "#add8a8",
+                        "selection": "#add8a833",
+                        "background": "#add8a8"
                     },
                     {
-                        "cursor": "#b0c4f5",
-                        "selection": "#b0c4f533",
-                        "background": "#b0c4f5"
+                        "cursor": "#8cc7e7",
+                        "selection": "#8cc7e733",
+                        "background": "#8cc7e7"
                     },
                     {
-                        "cursor": "#c8bff5",
-                        "selection": "#c8bff533",
-                        "background": "#c8bff5"
+                        "cursor": "#bac1f7",
+                        "selection": "#bac1f733",
+                        "background": "#bac1f7"
                     },
                     {
-                        "cursor": "#abcdee",
-                        "selection": "#abcdee33",
-                        "background": "#abcdee"
+                        "cursor": "#c6aaf6",
+                        "selection": "#c6aaf633",
+                        "background": "#c6aaf6"
                     }
                 ],
                 "syntax": {
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#dcb8d5ff",
-                    "#dfdad8ff",
-                    "#bddbd2ff",
-                    "#b6dae7ff",
-                    "#b2c8f6ff",
-                    "#ccc2f5ff",
-                    "#a9d0f0ff"
+                    "#eb9ab7ff",
+                    "#f1ba9dff",
+                    "#f0e0bdff",
+                    "#aee1b2ff",
+                    "#86caeeff",
+                    "#b9c3fcff",
+                    "#cbb0f7ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",
@@ -2241,39 +2241,39 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#dcb8d5",
-                        "selection": "#dcb8d533",
-                        "background": "#dcb8d5"
+                        "cursor": "#eb9ab7",
+                        "selection": "#eb9ab733",
+                        "background": "#eb9ab7"
                     },
                     {
-                        "cursor": "#dfdad8",
-                        "selection": "#dfdad833",
-                        "background": "#dfdad8"
+                        "cursor": "#f1ba9d",
+                        "selection": "#f1ba9d33",
+                        "background": "#f1ba9d"
                     },
                     {
-                        "cursor": "#bddbd2",
-                        "selection": "#bddbd233",
-                        "background": "#bddbd2"
+                        "cursor": "#f0e0bd",
+                        "selection": "#f0e0bd33",
+                        "background": "#f0e0bd"
                     },
                     {
-                        "cursor": "#b6dae7",
-                        "selection": "#b6dae733",
-                        "background": "#b6dae7"
+                        "cursor": "#aee1b2",
+                        "selection": "#aee1b233",
+                        "background": "#aee1b2"
                     },
                     {
-                        "cursor": "#b2c8f6",
-                        "selection": "#b2c8f633",
-                        "background": "#b2c8f6"
+                        "cursor": "#86caee",
+                        "selection": "#86caee33",
+                        "background": "#86caee"
                     },
                     {
-                        "cursor": "#ccc2f5",
-                        "selection": "#ccc2f533",
-                        "background": "#ccc2f5"
+                        "cursor": "#b9c3fc",
+                        "selection": "#b9c3fc33",
+                        "background": "#b9c3fc"
                     },
                     {
-                        "cursor": "#a9d0f0",
-                        "selection": "#a9d0f033",
-                        "background": "#a9d0f0"
+                        "cursor": "#cbb0f7",
+                        "selection": "#cbb0f733",
+                        "background": "#cbb0f7"
                     }
                 ],
                 "syntax": {

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -6,8 +6,16 @@
         {
             "name": "Catppuccin Latte - No Italics",
             "appearance": "light",
+            "accents": [
+                "#823556ff",
+                "#87684bff",
+                "#486f50ff",
+                "#37697cff",
+                "#3a58a1ff",
+                "#64469fff",
+                "#3b6f87ff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
                 "border.variant": "#9658eb",
@@ -154,24 +162,9 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#3b6f87",
-                        "selection": "#3b6f8733",
-                        "background": "#3b6f87"
-                    },
-                    {
                         "cursor": "#823556",
                         "selection": "#82355633",
                         "background": "#823556"
-                    },
-                    {
-                        "cursor": "#37697c",
-                        "selection": "#37697c33",
-                        "background": "#37697c"
-                    },
-                    {
-                        "cursor": "#945743",
-                        "selection": "#94574333",
-                        "background": "#945743"
                     },
                     {
                         "cursor": "#87684b",
@@ -179,14 +172,29 @@
                         "background": "#87684b"
                     },
                     {
+                        "cursor": "#486f50",
+                        "selection": "#486f5033",
+                        "background": "#486f50"
+                    },
+                    {
+                        "cursor": "#37697c",
+                        "selection": "#37697c33",
+                        "background": "#37697c"
+                    },
+                    {
                         "cursor": "#3a58a1",
                         "selection": "#3a58a133",
                         "background": "#3a58a1"
                     },
                     {
-                        "cursor": "#486f50",
-                        "selection": "#486f5033",
-                        "background": "#486f50"
+                        "cursor": "#64469f",
+                        "selection": "#64469f33",
+                        "background": "#64469f"
+                    },
+                    {
+                        "cursor": "#3b6f87",
+                        "selection": "#3b6f8733",
+                        "background": "#3b6f87"
                     }
                 ],
                 "syntax": {
@@ -691,8 +699,16 @@
         {
             "name": "Catppuccin Frappé - No Italics",
             "appearance": "dark",
+            "accents": [
+                "#d3b1c8ff",
+                "#d3cdcdff",
+                "#b9d1caff",
+                "#abcddfff",
+                "#afc1f2ff",
+                "#c8bcefff",
+                "#accaebff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#414559",
                 "border.variant": "#af8cca",
@@ -839,24 +855,9 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#accaeb",
-                        "selection": "#accaeb33",
-                        "background": "#accaeb"
-                    },
-                    {
                         "cursor": "#d3b1c8",
                         "selection": "#d3b1c833",
                         "background": "#d3b1c8"
-                    },
-                    {
-                        "cursor": "#abcddf",
-                        "selection": "#abcddf33",
-                        "background": "#abcddf"
-                    },
-                    {
-                        "cursor": "#d7bdc2",
-                        "selection": "#d7bdc233",
-                        "background": "#d7bdc2"
                     },
                     {
                         "cursor": "#d3cdcd",
@@ -864,14 +865,29 @@
                         "background": "#d3cdcd"
                     },
                     {
+                        "cursor": "#b9d1ca",
+                        "selection": "#b9d1ca33",
+                        "background": "#b9d1ca"
+                    },
+                    {
+                        "cursor": "#abcddf",
+                        "selection": "#abcddf33",
+                        "background": "#abcddf"
+                    },
+                    {
                         "cursor": "#afc1f2",
                         "selection": "#afc1f233",
                         "background": "#afc1f2"
                     },
                     {
-                        "cursor": "#b9d1ca",
-                        "selection": "#b9d1ca33",
-                        "background": "#b9d1ca"
+                        "cursor": "#c8bcef",
+                        "selection": "#c8bcef33",
+                        "background": "#c8bcef"
+                    },
+                    {
+                        "cursor": "#accaeb",
+                        "selection": "#accaeb33",
+                        "background": "#accaeb"
                     }
                 ],
                 "syntax": {
@@ -1376,8 +1392,16 @@
         {
             "name": "Catppuccin Macchiato - No Italics",
             "appearance": "dark",
+            "accents": [
+                "#d8b5cfff",
+                "#d8d4d3ff",
+                "#bbd6cfff",
+                "#b1d4e4ff",
+                "#b0c4f5ff",
+                "#c8bff5ff",
+                "#abcdeeff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
                 "border.variant": "#a98cd5",
@@ -1524,24 +1548,9 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#abcdee",
-                        "selection": "#abcdee33",
-                        "background": "#abcdee"
-                    },
-                    {
                         "cursor": "#d8b5cf",
                         "selection": "#d8b5cf33",
                         "background": "#d8b5cf"
-                    },
-                    {
-                        "cursor": "#b1d4e4",
-                        "selection": "#b1d4e433",
-                        "background": "#b1d4e4"
-                    },
-                    {
-                        "cursor": "#dbc3c6",
-                        "selection": "#dbc3c633",
-                        "background": "#dbc3c6"
                     },
                     {
                         "cursor": "#d8d4d3",
@@ -1549,14 +1558,29 @@
                         "background": "#d8d4d3"
                     },
                     {
+                        "cursor": "#bbd6cf",
+                        "selection": "#bbd6cf33",
+                        "background": "#bbd6cf"
+                    },
+                    {
+                        "cursor": "#b1d4e4",
+                        "selection": "#b1d4e433",
+                        "background": "#b1d4e4"
+                    },
+                    {
                         "cursor": "#b0c4f5",
                         "selection": "#b0c4f533",
                         "background": "#b0c4f5"
                     },
                     {
-                        "cursor": "#bbd6cf",
-                        "selection": "#bbd6cf33",
-                        "background": "#bbd6cf"
+                        "cursor": "#c8bff5",
+                        "selection": "#c8bff533",
+                        "background": "#c8bff5"
+                    },
+                    {
+                        "cursor": "#abcdee",
+                        "selection": "#abcdee33",
+                        "background": "#abcdee"
                     }
                 ],
                 "syntax": {
@@ -2061,8 +2085,16 @@
         {
             "name": "Catppuccin Mocha - No Italics",
             "appearance": "dark",
+            "accents": [
+                "#dcb8d5ff",
+                "#dfdad8ff",
+                "#bddbd2ff",
+                "#b6dae7ff",
+                "#b2c8f6ff",
+                "#ccc2f5ff",
+                "#a9d0f0ff"
+            ],
             "style": {
-                "accent": [],
                 "background.appearance": "opaque",
                 "border": "#313244",
                 "border.variant": "#ac8fd4",
@@ -2209,24 +2241,9 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#a9d0f0",
-                        "selection": "#a9d0f033",
-                        "background": "#a9d0f0"
-                    },
-                    {
                         "cursor": "#dcb8d5",
                         "selection": "#dcb8d533",
                         "background": "#dcb8d5"
-                    },
-                    {
-                        "cursor": "#b6dae7",
-                        "selection": "#b6dae733",
-                        "background": "#b6dae7"
-                    },
-                    {
-                        "cursor": "#dfc8c8",
-                        "selection": "#dfc8c833",
-                        "background": "#dfc8c8"
                     },
                     {
                         "cursor": "#dfdad8",
@@ -2234,14 +2251,29 @@
                         "background": "#dfdad8"
                     },
                     {
+                        "cursor": "#bddbd2",
+                        "selection": "#bddbd233",
+                        "background": "#bddbd2"
+                    },
+                    {
+                        "cursor": "#b6dae7",
+                        "selection": "#b6dae733",
+                        "background": "#b6dae7"
+                    },
+                    {
                         "cursor": "#b2c8f6",
                         "selection": "#b2c8f633",
                         "background": "#b2c8f6"
                     },
                     {
-                        "cursor": "#bddbd2",
-                        "selection": "#bddbd233",
-                        "background": "#bddbd2"
+                        "cursor": "#ccc2f5",
+                        "selection": "#ccc2f533",
+                        "background": "#ccc2f5"
+                    },
+                    {
+                        "cursor": "#a9d0f0",
+                        "selection": "#a9d0f033",
+                        "background": "#a9d0f0"
                     }
                 ],
                 "syntax": {

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#823556ff",
-                    "#87684bff",
-                    "#486f50ff",
-                    "#37697cff",
-                    "#3a58a1ff",
-                    "#64469fff",
-                    "#3b6f87ff"
+                    "#b71c43ff",
+                    "#da601eff",
+                    "#c1822cff",
+                    "#429037ff",
+                    "#298fa6ff",
+                    "#6a7cdfff",
+                    "#7c3ed4ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -162,39 +162,39 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#823556",
-                        "selection": "#82355633",
-                        "background": "#823556"
+                        "cursor": "#b71c43",
+                        "selection": "#b71c4333",
+                        "background": "#b71c43"
                     },
                     {
-                        "cursor": "#87684b",
-                        "selection": "#87684b33",
-                        "background": "#87684b"
+                        "cursor": "#da601e",
+                        "selection": "#da601e33",
+                        "background": "#da601e"
                     },
                     {
-                        "cursor": "#486f50",
-                        "selection": "#486f5033",
-                        "background": "#486f50"
+                        "cursor": "#c1822c",
+                        "selection": "#c1822c33",
+                        "background": "#c1822c"
                     },
                     {
-                        "cursor": "#37697c",
-                        "selection": "#37697c33",
-                        "background": "#37697c"
+                        "cursor": "#429037",
+                        "selection": "#42903733",
+                        "background": "#429037"
                     },
                     {
-                        "cursor": "#3a58a1",
-                        "selection": "#3a58a133",
-                        "background": "#3a58a1"
+                        "cursor": "#298fa6",
+                        "selection": "#298fa633",
+                        "background": "#298fa6"
                     },
                     {
-                        "cursor": "#64469f",
-                        "selection": "#64469f33",
-                        "background": "#64469f"
+                        "cursor": "#6a7cdf",
+                        "selection": "#6a7cdf33",
+                        "background": "#6a7cdf"
                     },
                     {
-                        "cursor": "#3b6f87",
-                        "selection": "#3b6f8733",
-                        "background": "#3b6f87"
+                        "cursor": "#7c3ed4",
+                        "selection": "#7c3ed433",
+                        "background": "#7c3ed4"
                     }
                 ],
                 "syntax": {
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#d3b1c8ff",
-                    "#d3cdcdff",
-                    "#b9d1caff",
-                    "#abcddfff",
-                    "#afc1f2ff",
-                    "#c8bcefff",
-                    "#accaebff"
+                    "#e1929bff",
+                    "#e7a98fff",
+                    "#dfcaa4ff",
+                    "#add19fff",
+                    "#92c4e1ff",
+                    "#bdc0f2ff",
+                    "#caa8e9ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -855,39 +855,39 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#d3b1c8",
-                        "selection": "#d3b1c833",
-                        "background": "#d3b1c8"
+                        "cursor": "#e1929b",
+                        "selection": "#e1929b33",
+                        "background": "#e1929b"
                     },
                     {
-                        "cursor": "#d3cdcd",
-                        "selection": "#d3cdcd33",
-                        "background": "#d3cdcd"
+                        "cursor": "#e7a98f",
+                        "selection": "#e7a98f33",
+                        "background": "#e7a98f"
                     },
                     {
-                        "cursor": "#b9d1ca",
-                        "selection": "#b9d1ca33",
-                        "background": "#b9d1ca"
+                        "cursor": "#dfcaa4",
+                        "selection": "#dfcaa433",
+                        "background": "#dfcaa4"
                     },
                     {
-                        "cursor": "#abcddf",
-                        "selection": "#abcddf33",
-                        "background": "#abcddf"
+                        "cursor": "#add19f",
+                        "selection": "#add19f33",
+                        "background": "#add19f"
                     },
                     {
-                        "cursor": "#afc1f2",
-                        "selection": "#afc1f233",
-                        "background": "#afc1f2"
+                        "cursor": "#92c4e1",
+                        "selection": "#92c4e133",
+                        "background": "#92c4e1"
                     },
                     {
-                        "cursor": "#c8bcef",
-                        "selection": "#c8bcef33",
-                        "background": "#c8bcef"
+                        "cursor": "#bdc0f2",
+                        "selection": "#bdc0f233",
+                        "background": "#bdc0f2"
                     },
                     {
-                        "cursor": "#accaeb",
-                        "selection": "#accaeb33",
-                        "background": "#accaeb"
+                        "cursor": "#caa8e9",
+                        "selection": "#caa8e933",
+                        "background": "#caa8e9"
                     }
                 ],
                 "syntax": {
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#d8b5cfff",
-                    "#d8d4d3ff",
-                    "#bbd6cfff",
-                    "#b1d4e4ff",
-                    "#b0c4f5ff",
-                    "#c8bff5ff",
-                    "#abcdeeff"
+                    "#e696a9ff",
+                    "#ecb197ff",
+                    "#e6d4b0ff",
+                    "#add8a8ff",
+                    "#8cc7e7ff",
+                    "#bac1f7ff",
+                    "#c6aaf6ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -1548,39 +1548,39 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#d8b5cf",
-                        "selection": "#d8b5cf33",
-                        "background": "#d8b5cf"
+                        "cursor": "#e696a9",
+                        "selection": "#e696a933",
+                        "background": "#e696a9"
                     },
                     {
-                        "cursor": "#d8d4d3",
-                        "selection": "#d8d4d333",
-                        "background": "#d8d4d3"
+                        "cursor": "#ecb197",
+                        "selection": "#ecb19733",
+                        "background": "#ecb197"
                     },
                     {
-                        "cursor": "#bbd6cf",
-                        "selection": "#bbd6cf33",
-                        "background": "#bbd6cf"
+                        "cursor": "#e6d4b0",
+                        "selection": "#e6d4b033",
+                        "background": "#e6d4b0"
                     },
                     {
-                        "cursor": "#b1d4e4",
-                        "selection": "#b1d4e433",
-                        "background": "#b1d4e4"
+                        "cursor": "#add8a8",
+                        "selection": "#add8a833",
+                        "background": "#add8a8"
                     },
                     {
-                        "cursor": "#b0c4f5",
-                        "selection": "#b0c4f533",
-                        "background": "#b0c4f5"
+                        "cursor": "#8cc7e7",
+                        "selection": "#8cc7e733",
+                        "background": "#8cc7e7"
                     },
                     {
-                        "cursor": "#c8bff5",
-                        "selection": "#c8bff533",
-                        "background": "#c8bff5"
+                        "cursor": "#bac1f7",
+                        "selection": "#bac1f733",
+                        "background": "#bac1f7"
                     },
                     {
-                        "cursor": "#abcdee",
-                        "selection": "#abcdee33",
-                        "background": "#abcdee"
+                        "cursor": "#c6aaf6",
+                        "selection": "#c6aaf633",
+                        "background": "#c6aaf6"
                     }
                 ],
                 "syntax": {
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#dcb8d5ff",
-                    "#dfdad8ff",
-                    "#bddbd2ff",
-                    "#b6dae7ff",
-                    "#b2c8f6ff",
-                    "#ccc2f5ff",
-                    "#a9d0f0ff"
+                    "#eb9ab7ff",
+                    "#f1ba9dff",
+                    "#f0e0bdff",
+                    "#aee1b2ff",
+                    "#86caeeff",
+                    "#b9c3fcff",
+                    "#cbb0f7ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",
@@ -2241,39 +2241,39 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#dcb8d5",
-                        "selection": "#dcb8d533",
-                        "background": "#dcb8d5"
+                        "cursor": "#eb9ab7",
+                        "selection": "#eb9ab733",
+                        "background": "#eb9ab7"
                     },
                     {
-                        "cursor": "#dfdad8",
-                        "selection": "#dfdad833",
-                        "background": "#dfdad8"
+                        "cursor": "#f1ba9d",
+                        "selection": "#f1ba9d33",
+                        "background": "#f1ba9d"
                     },
                     {
-                        "cursor": "#bddbd2",
-                        "selection": "#bddbd233",
-                        "background": "#bddbd2"
+                        "cursor": "#f0e0bd",
+                        "selection": "#f0e0bd33",
+                        "background": "#f0e0bd"
                     },
                     {
-                        "cursor": "#b6dae7",
-                        "selection": "#b6dae733",
-                        "background": "#b6dae7"
+                        "cursor": "#aee1b2",
+                        "selection": "#aee1b233",
+                        "background": "#aee1b2"
                     },
                     {
-                        "cursor": "#b2c8f6",
-                        "selection": "#b2c8f633",
-                        "background": "#b2c8f6"
+                        "cursor": "#86caee",
+                        "selection": "#86caee33",
+                        "background": "#86caee"
                     },
                     {
-                        "cursor": "#ccc2f5",
-                        "selection": "#ccc2f533",
-                        "background": "#ccc2f5"
+                        "cursor": "#b9c3fc",
+                        "selection": "#b9c3fc33",
+                        "background": "#b9c3fc"
                     },
                     {
-                        "cursor": "#a9d0f0",
-                        "selection": "#a9d0f033",
-                        "background": "#a9d0f0"
+                        "cursor": "#cbb0f7",
+                        "selection": "#cbb0f733",
+                        "background": "#cbb0f7"
                     }
                 ],
                 "syntax": {

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -6,16 +6,16 @@
         {
             "name": "Catppuccin Latte - No Italics",
             "appearance": "light",
-            "accents": [
-                "#823556ff",
-                "#87684bff",
-                "#486f50ff",
-                "#37697cff",
-                "#3a58a1ff",
-                "#64469fff",
-                "#3b6f87ff"
-            ],
             "style": {
+                "accents": [
+                    "#823556ff",
+                    "#87684bff",
+                    "#486f50ff",
+                    "#37697cff",
+                    "#3a58a1ff",
+                    "#64469fff",
+                    "#3b6f87ff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
                 "border.variant": "#9658eb",
@@ -699,16 +699,16 @@
         {
             "name": "Catppuccin Frappé - No Italics",
             "appearance": "dark",
-            "accents": [
-                "#d3b1c8ff",
-                "#d3cdcdff",
-                "#b9d1caff",
-                "#abcddfff",
-                "#afc1f2ff",
-                "#c8bcefff",
-                "#accaebff"
-            ],
             "style": {
+                "accents": [
+                    "#d3b1c8ff",
+                    "#d3cdcdff",
+                    "#b9d1caff",
+                    "#abcddfff",
+                    "#afc1f2ff",
+                    "#c8bcefff",
+                    "#accaebff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#414559",
                 "border.variant": "#af8cca",
@@ -1392,16 +1392,16 @@
         {
             "name": "Catppuccin Macchiato - No Italics",
             "appearance": "dark",
-            "accents": [
-                "#d8b5cfff",
-                "#d8d4d3ff",
-                "#bbd6cfff",
-                "#b1d4e4ff",
-                "#b0c4f5ff",
-                "#c8bff5ff",
-                "#abcdeeff"
-            ],
             "style": {
+                "accents": [
+                    "#d8b5cfff",
+                    "#d8d4d3ff",
+                    "#bbd6cfff",
+                    "#b1d4e4ff",
+                    "#b0c4f5ff",
+                    "#c8bff5ff",
+                    "#abcdeeff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
                 "border.variant": "#a98cd5",
@@ -2085,16 +2085,16 @@
         {
             "name": "Catppuccin Mocha - No Italics",
             "appearance": "dark",
-            "accents": [
-                "#dcb8d5ff",
-                "#dfdad8ff",
-                "#bddbd2ff",
-                "#b6dae7ff",
-                "#b2c8f6ff",
-                "#ccc2f5ff",
-                "#a9d0f0ff"
-            ],
             "style": {
+                "accents": [
+                    "#dcb8d5ff",
+                    "#dfdad8ff",
+                    "#bddbd2ff",
+                    "#b6dae7ff",
+                    "#b2c8f6ff",
+                    "#ccc2f5ff",
+                    "#a9d0f0ff"
+                ],
                 "background.appearance": "opaque",
                 "border": "#313244",
                 "border.variant": "#ac8fd4",

--- a/zed.tera
+++ b/zed.tera
@@ -14,21 +14,26 @@ whiskers:
     "themes": [
         {%- for _, flavor in flavors -%}
         {%- set c = flavor.colors -%}
-        {% set players = [
-            c.text  | mix(color=c.sapphire, amount=0.6),
+        {% set rainbow = [
             c.text  | mix(color=c.red, amount=0.6),
-            c.text  | mix(color=c.teal, amount=0.6),
-            c.text  | mix(color=c.peach, amount=0.6),
             c.text  | mix(color=c.yellow, amount=0.6),
-            c.text  | mix(color=c.blue, amount=0.6),
             c.text  | mix(color=c.green, amount=0.6),
+            c.text  | mix(color=c.teal, amount=0.6),
+            c.text  | mix(color=c.blue, amount=0.6),
+            c.text  | mix(color=c.mauve, amount=0.6),
+            c.text  | mix(color=c.sapphire, amount=0.6),
         ] -%}
         {%- set italics = if(cond=variant == "-no-italics", t="null", f='"italic"') %}
         {
             "name": "Catppuccin {{ flavor.name }} {%- if accent != 'mauve' %} ({{ accent }}) {%- endif -%} {%- if variant == "-no-italics" %} - No Italics {%- endif -%}",
             "appearance": {% if flavor.dark %}"dark"{% else %}"light"{% endif %},
+            "accents": [
+            {#- NOTE: not Catppuccin accents, but for indent_aware coloring #}
+            {%- for color in rainbow %}
+                "#{{ color.hex }}ff"{%- if not loop.last %},{% endif -%}
+            {% endfor %}
+            ],
             "style": {
-                "accent": [], {#- TODO (doesn't seem to do anything now) #}
                 "background.appearance": "opaque", {#- all others remove app window shadow-backdrop on macOS #}
                 "border": "#{{ c.surface0.hex }}",
                 "border.variant": "#{{ c[accent] | mix(color=c.surface0, amount=0.8) | get(key="hex") }}",
@@ -180,11 +185,11 @@ whiskers:
                         "selection": "#{{ c.surface2 | mod(opacity=0.5) | get(key="hex") }}",
                         "background": "#{{ c.rosewater.hex }}"
                     },
-                    {%- for player in players %}
+                    {%- for color in rainbow %}
                     {
-                        "cursor": "#{{ player.hex }}",
-                        "selection": "#{{ player | mod(opacity=0.2) | get(key="hex") }}",
-                        "background": "#{{ player.hex }}"
+                        "cursor": "#{{ color.hex }}",
+                        "selection": "#{{ color | mod(opacity=0.2) | get(key="hex") }}",
+                        "background": "#{{ color.hex }}"
                     }{% if not loop.last %},{% endif -%}
                     {% endfor %}
                 ],

--- a/zed.tera
+++ b/zed.tera
@@ -15,13 +15,13 @@ whiskers:
         {%- for _, flavor in flavors -%}
         {%- set c = flavor.colors -%}
         {% set rainbow = [
-            c.text  | mix(color=c.red, amount=0.6),
-            c.text  | mix(color=c.yellow, amount=0.6),
-            c.text  | mix(color=c.green, amount=0.6),
-            c.text  | mix(color=c.teal, amount=0.6),
-            c.text  | mix(color=c.blue, amount=0.6),
-            c.text  | mix(color=c.mauve, amount=0.6),
-            c.text  | mix(color=c.sapphire, amount=0.6),
+            c.red       | mix(color=c.text, amount=0.8),
+            c.peach     | mix(color=c.text, amount=0.8),
+            c.yellow    | mix(color=c.text, amount=0.8),
+            c.green     | mix(color=c.text, amount=0.8),
+            c.sapphire  | mix(color=c.text, amount=0.8),
+            c.lavender  | mix(color=c.text, amount=0.8),
+            c.mauve     | mix(color=c.text, amount=0.8),
         ] -%}
         {%- set italics = if(cond=variant == "-no-italics", t="null", f='"italic"') %}
         {

--- a/zed.tera
+++ b/zed.tera
@@ -27,13 +27,13 @@ whiskers:
         {
             "name": "Catppuccin {{ flavor.name }} {%- if accent != 'mauve' %} ({{ accent }}) {%- endif -%} {%- if variant == "-no-italics" %} - No Italics {%- endif -%}",
             "appearance": {% if flavor.dark %}"dark"{% else %}"light"{% endif %},
-            "accents": [
-            {#- NOTE: not Catppuccin accents, but for indent_aware coloring #}
-            {%- for color in rainbow %}
-                "#{{ color.hex }}ff"{%- if not loop.last %},{% endif -%}
-            {% endfor %}
-            ],
             "style": {
+                "accents": [
+                {#- NOTE: not Catppuccin accents, but for indent_aware coloring #}
+                {%- for color in rainbow %}
+                    "#{{ color.hex }}ff"{%- if not loop.last %},{% endif -%}
+                {% endfor %}
+                ],
                 "background.appearance": "opaque", {#- all others remove app window shadow-backdrop on macOS #}
                 "border": "#{{ c.surface0.hex }}",
                 "border.variant": "#{{ c[accent] | mix(color=c.surface0, amount=0.8) | get(key="hex") }}",


### PR DESCRIPTION
- use defined `accents` key as mentioned in docs: for `indent_aware` colors 

https://zed.dev/docs/configuring-zed#indent-guides

requires `settings.json` params:

```
"indent_guides": {
  "enabled": true,
  "coloring": "indent_aware",
  "background_coloring": "indent_aware"
},
```

before 🌦️ :
<img width="548" alt="image" src="https://github.com/user-attachments/assets/323c82f4-da52-40a3-8145-7b8b9f09822d">

<img width="611" alt="image" src="https://github.com/user-attachments/assets/082087d3-0ae9-4216-8e5a-049887f4e6cf">



after 🌈 :
<img width="592" alt="image" src="https://github.com/user-attachments/assets/7f999c40-7b1c-452c-991f-95686947190b">


<img width="632" alt="image" src="https://github.com/user-attachments/assets/da23b8ca-304c-4b68-b036-8dc438a100c4">
