### PR TITLE
fix(syntax): match `string.doc` to `string.documentation`

### DIFF
--- a/zed.tera
+++ b/zed.tera
@@ -694,7 +694,7 @@ whiskers:
                         "font_weight": null
                     },
                     "string.doc": {
-                      "color": "#{{ c.overlay2.hex }}",
+                      "color": "#{{ c.teal.hex }}",
                       "font_style": {{ italics }},
                       "font_weight": null
                     },


### PR DESCRIPTION
Closes #63. Zed should just be using `string.documentation` here instead of `string.doc` but here we are.