### PR TITLE
fix: reverse rainbow coloring order

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#b71c43ff",
-                    "#da601eff",
-                    "#c1822cff",
-                    "#429037ff",
-                    "#298fa6ff",
+                    "#7c3ed4ff",
                     "#6a7cdfff",
-                    "#7c3ed4ff"
+                    "#298fa6ff",
+                    "#429037ff",
+                    "#c1822cff",
+                    "#da601eff",
+                    "#b71c43ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#e1929bff",
-                    "#e7a98fff",
-                    "#dfcaa4ff",
-                    "#add19fff",
-                    "#92c4e1ff",
+                    "#caa8e9ff",
                     "#bdc0f2ff",
-                    "#caa8e9ff"
+                    "#92c4e1ff",
+                    "#add19fff",
+                    "#dfcaa4ff",
+                    "#e7a98fff",
+                    "#e1929bff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#e696a9ff",
-                    "#ecb197ff",
-                    "#e6d4b0ff",
-                    "#add8a8ff",
-                    "#8cc7e7ff",
+                    "#c6aaf6ff",
                     "#bac1f7ff",
-                    "#c6aaf6ff"
+                    "#8cc7e7ff",
+                    "#add8a8ff",
+                    "#e6d4b0ff",
+                    "#ecb197ff",
+                    "#e696a9ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#eb9ab7ff",
-                    "#f1ba9dff",
-                    "#f0e0bdff",
-                    "#aee1b2ff",
-                    "#86caeeff",
+                    "#cbb0f7ff",
                     "#b9c3fcff",
-                    "#cbb0f7ff"
+                    "#86caeeff",
+                    "#aee1b2ff",
+                    "#f0e0bdff",
+                    "#f1ba9dff",
+                    "#eb9ab7ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#7c3ed4ff",
-                    "#6a7cdfff",
-                    "#298fa6ff",
-                    "#429037ff",
-                    "#c1822cff",
-                    "#da601eff",
-                    "#b71c43ff"
+                    "#7c3ed466",
+                    "#6a7cdf66",
+                    "#298fa666",
+                    "#42903766",
+                    "#c1822c66",
+                    "#da601e66",
+                    "#b71c4366"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#caa8e9ff",
-                    "#bdc0f2ff",
-                    "#92c4e1ff",
-                    "#add19fff",
-                    "#dfcaa4ff",
-                    "#e7a98fff",
-                    "#e1929bff"
+                    "#caa8e966",
+                    "#bdc0f266",
+                    "#92c4e166",
+                    "#add19f66",
+                    "#dfcaa466",
+                    "#e7a98f66",
+                    "#e1929b66"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#c6aaf6ff",
-                    "#bac1f7ff",
-                    "#8cc7e7ff",
-                    "#add8a8ff",
-                    "#e6d4b0ff",
-                    "#ecb197ff",
-                    "#e696a9ff"
+                    "#c6aaf666",
+                    "#bac1f766",
+                    "#8cc7e766",
+                    "#add8a866",
+                    "#e6d4b066",
+                    "#ecb19766",
+                    "#e696a966"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#cbb0f7ff",
-                    "#b9c3fcff",
-                    "#86caeeff",
-                    "#aee1b2ff",
-                    "#f0e0bdff",
-                    "#f1ba9dff",
-                    "#eb9ab7ff"
+                    "#cbb0f766",
+                    "#b9c3fc66",
+                    "#86caee66",
+                    "#aee1b266",
+                    "#f0e0bd66",
+                    "#f1ba9d66",
+                    "#eb9ab766"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",

--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -162,29 +162,9 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#b71c43",
-                        "selection": "#b71c4333",
-                        "background": "#b71c43"
-                    },
-                    {
-                        "cursor": "#da601e",
-                        "selection": "#da601e33",
-                        "background": "#da601e"
-                    },
-                    {
-                        "cursor": "#c1822c",
-                        "selection": "#c1822c33",
-                        "background": "#c1822c"
-                    },
-                    {
-                        "cursor": "#429037",
-                        "selection": "#42903733",
-                        "background": "#429037"
-                    },
-                    {
-                        "cursor": "#298fa6",
-                        "selection": "#298fa633",
-                        "background": "#298fa6"
+                        "cursor": "#7c3ed4",
+                        "selection": "#7c3ed433",
+                        "background": "#7c3ed4"
                     },
                     {
                         "cursor": "#6a7cdf",
@@ -192,9 +172,29 @@
                         "background": "#6a7cdf"
                     },
                     {
-                        "cursor": "#7c3ed4",
-                        "selection": "#7c3ed433",
-                        "background": "#7c3ed4"
+                        "cursor": "#298fa6",
+                        "selection": "#298fa633",
+                        "background": "#298fa6"
+                    },
+                    {
+                        "cursor": "#429037",
+                        "selection": "#42903733",
+                        "background": "#429037"
+                    },
+                    {
+                        "cursor": "#c1822c",
+                        "selection": "#c1822c33",
+                        "background": "#c1822c"
+                    },
+                    {
+                        "cursor": "#da601e",
+                        "selection": "#da601e33",
+                        "background": "#da601e"
+                    },
+                    {
+                        "cursor": "#b71c43",
+                        "selection": "#b71c4333",
+                        "background": "#b71c43"
                     }
                 ],
                 "syntax": {
@@ -855,29 +855,9 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#e1929b",
-                        "selection": "#e1929b33",
-                        "background": "#e1929b"
-                    },
-                    {
-                        "cursor": "#e7a98f",
-                        "selection": "#e7a98f33",
-                        "background": "#e7a98f"
-                    },
-                    {
-                        "cursor": "#dfcaa4",
-                        "selection": "#dfcaa433",
-                        "background": "#dfcaa4"
-                    },
-                    {
-                        "cursor": "#add19f",
-                        "selection": "#add19f33",
-                        "background": "#add19f"
-                    },
-                    {
-                        "cursor": "#92c4e1",
-                        "selection": "#92c4e133",
-                        "background": "#92c4e1"
+                        "cursor": "#caa8e9",
+                        "selection": "#caa8e933",
+                        "background": "#caa8e9"
                     },
                     {
                         "cursor": "#bdc0f2",
@@ -885,9 +865,29 @@
                         "background": "#bdc0f2"
                     },
                     {
-                        "cursor": "#caa8e9",
-                        "selection": "#caa8e933",
-                        "background": "#caa8e9"
+                        "cursor": "#92c4e1",
+                        "selection": "#92c4e133",
+                        "background": "#92c4e1"
+                    },
+                    {
+                        "cursor": "#add19f",
+                        "selection": "#add19f33",
+                        "background": "#add19f"
+                    },
+                    {
+                        "cursor": "#dfcaa4",
+                        "selection": "#dfcaa433",
+                        "background": "#dfcaa4"
+                    },
+                    {
+                        "cursor": "#e7a98f",
+                        "selection": "#e7a98f33",
+                        "background": "#e7a98f"
+                    },
+                    {
+                        "cursor": "#e1929b",
+                        "selection": "#e1929b33",
+                        "background": "#e1929b"
                     }
                 ],
                 "syntax": {
@@ -1548,29 +1548,9 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#e696a9",
-                        "selection": "#e696a933",
-                        "background": "#e696a9"
-                    },
-                    {
-                        "cursor": "#ecb197",
-                        "selection": "#ecb19733",
-                        "background": "#ecb197"
-                    },
-                    {
-                        "cursor": "#e6d4b0",
-                        "selection": "#e6d4b033",
-                        "background": "#e6d4b0"
-                    },
-                    {
-                        "cursor": "#add8a8",
-                        "selection": "#add8a833",
-                        "background": "#add8a8"
-                    },
-                    {
-                        "cursor": "#8cc7e7",
-                        "selection": "#8cc7e733",
-                        "background": "#8cc7e7"
+                        "cursor": "#c6aaf6",
+                        "selection": "#c6aaf633",
+                        "background": "#c6aaf6"
                     },
                     {
                         "cursor": "#bac1f7",
@@ -1578,9 +1558,29 @@
                         "background": "#bac1f7"
                     },
                     {
-                        "cursor": "#c6aaf6",
-                        "selection": "#c6aaf633",
-                        "background": "#c6aaf6"
+                        "cursor": "#8cc7e7",
+                        "selection": "#8cc7e733",
+                        "background": "#8cc7e7"
+                    },
+                    {
+                        "cursor": "#add8a8",
+                        "selection": "#add8a833",
+                        "background": "#add8a8"
+                    },
+                    {
+                        "cursor": "#e6d4b0",
+                        "selection": "#e6d4b033",
+                        "background": "#e6d4b0"
+                    },
+                    {
+                        "cursor": "#ecb197",
+                        "selection": "#ecb19733",
+                        "background": "#ecb197"
+                    },
+                    {
+                        "cursor": "#e696a9",
+                        "selection": "#e696a933",
+                        "background": "#e696a9"
                     }
                 ],
                 "syntax": {
@@ -2241,29 +2241,9 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#eb9ab7",
-                        "selection": "#eb9ab733",
-                        "background": "#eb9ab7"
-                    },
-                    {
-                        "cursor": "#f1ba9d",
-                        "selection": "#f1ba9d33",
-                        "background": "#f1ba9d"
-                    },
-                    {
-                        "cursor": "#f0e0bd",
-                        "selection": "#f0e0bd33",
-                        "background": "#f0e0bd"
-                    },
-                    {
-                        "cursor": "#aee1b2",
-                        "selection": "#aee1b233",
-                        "background": "#aee1b2"
-                    },
-                    {
-                        "cursor": "#86caee",
-                        "selection": "#86caee33",
-                        "background": "#86caee"
+                        "cursor": "#cbb0f7",
+                        "selection": "#cbb0f733",
+                        "background": "#cbb0f7"
                     },
                     {
                         "cursor": "#b9c3fc",
@@ -2271,9 +2251,29 @@
                         "background": "#b9c3fc"
                     },
                     {
-                        "cursor": "#cbb0f7",
-                        "selection": "#cbb0f733",
-                        "background": "#cbb0f7"
+                        "cursor": "#86caee",
+                        "selection": "#86caee33",
+                        "background": "#86caee"
+                    },
+                    {
+                        "cursor": "#aee1b2",
+                        "selection": "#aee1b233",
+                        "background": "#aee1b2"
+                    },
+                    {
+                        "cursor": "#f0e0bd",
+                        "selection": "#f0e0bd33",
+                        "background": "#f0e0bd"
+                    },
+                    {
+                        "cursor": "#f1ba9d",
+                        "selection": "#f1ba9d33",
+                        "background": "#f1ba9d"
+                    },
+                    {
+                        "cursor": "#eb9ab7",
+                        "selection": "#eb9ab733",
+                        "background": "#eb9ab7"
                     }
                 ],
                 "syntax": {

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#b71c43ff",
-                    "#da601eff",
-                    "#c1822cff",
-                    "#429037ff",
-                    "#298fa6ff",
+                    "#7c3ed4ff",
                     "#6a7cdfff",
-                    "#7c3ed4ff"
+                    "#298fa6ff",
+                    "#429037ff",
+                    "#c1822cff",
+                    "#da601eff",
+                    "#b71c43ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#e1929bff",
-                    "#e7a98fff",
-                    "#dfcaa4ff",
-                    "#add19fff",
-                    "#92c4e1ff",
+                    "#caa8e9ff",
                     "#bdc0f2ff",
-                    "#caa8e9ff"
+                    "#92c4e1ff",
+                    "#add19fff",
+                    "#dfcaa4ff",
+                    "#e7a98fff",
+                    "#e1929bff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#e696a9ff",
-                    "#ecb197ff",
-                    "#e6d4b0ff",
-                    "#add8a8ff",
-                    "#8cc7e7ff",
+                    "#c6aaf6ff",
                     "#bac1f7ff",
-                    "#c6aaf6ff"
+                    "#8cc7e7ff",
+                    "#add8a8ff",
+                    "#e6d4b0ff",
+                    "#ecb197ff",
+                    "#e696a9ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#eb9ab7ff",
-                    "#f1ba9dff",
-                    "#f0e0bdff",
-                    "#aee1b2ff",
-                    "#86caeeff",
+                    "#cbb0f7ff",
                     "#b9c3fcff",
-                    "#cbb0f7ff"
+                    "#86caeeff",
+                    "#aee1b2ff",
+                    "#f0e0bdff",
+                    "#f1ba9dff",
+                    "#eb9ab7ff"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -8,13 +8,13 @@
             "appearance": "light",
             "style": {
                 "accents": [
-                    "#7c3ed4ff",
-                    "#6a7cdfff",
-                    "#298fa6ff",
-                    "#429037ff",
-                    "#c1822cff",
-                    "#da601eff",
-                    "#b71c43ff"
+                    "#7c3ed466",
+                    "#6a7cdf66",
+                    "#298fa666",
+                    "#42903766",
+                    "#c1822c66",
+                    "#da601e66",
+                    "#b71c4366"
                 ],
                 "background.appearance": "opaque",
                 "border": "#ccd0da",
@@ -701,13 +701,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#caa8e9ff",
-                    "#bdc0f2ff",
-                    "#92c4e1ff",
-                    "#add19fff",
-                    "#dfcaa4ff",
-                    "#e7a98fff",
-                    "#e1929bff"
+                    "#caa8e966",
+                    "#bdc0f266",
+                    "#92c4e166",
+                    "#add19f66",
+                    "#dfcaa466",
+                    "#e7a98f66",
+                    "#e1929b66"
                 ],
                 "background.appearance": "opaque",
                 "border": "#414559",
@@ -1394,13 +1394,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#c6aaf6ff",
-                    "#bac1f7ff",
-                    "#8cc7e7ff",
-                    "#add8a8ff",
-                    "#e6d4b0ff",
-                    "#ecb197ff",
-                    "#e696a9ff"
+                    "#c6aaf666",
+                    "#bac1f766",
+                    "#8cc7e766",
+                    "#add8a866",
+                    "#e6d4b066",
+                    "#ecb19766",
+                    "#e696a966"
                 ],
                 "background.appearance": "opaque",
                 "border": "#363a4f",
@@ -2087,13 +2087,13 @@
             "appearance": "dark",
             "style": {
                 "accents": [
-                    "#cbb0f7ff",
-                    "#b9c3fcff",
-                    "#86caeeff",
-                    "#aee1b2ff",
-                    "#f0e0bdff",
-                    "#f1ba9dff",
-                    "#eb9ab7ff"
+                    "#cbb0f766",
+                    "#b9c3fc66",
+                    "#86caee66",
+                    "#aee1b266",
+                    "#f0e0bd66",
+                    "#f1ba9d66",
+                    "#eb9ab766"
                 ],
                 "background.appearance": "opaque",
                 "border": "#313244",

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -162,29 +162,9 @@
                         "background": "#dc8a78"
                     },
                     {
-                        "cursor": "#b71c43",
-                        "selection": "#b71c4333",
-                        "background": "#b71c43"
-                    },
-                    {
-                        "cursor": "#da601e",
-                        "selection": "#da601e33",
-                        "background": "#da601e"
-                    },
-                    {
-                        "cursor": "#c1822c",
-                        "selection": "#c1822c33",
-                        "background": "#c1822c"
-                    },
-                    {
-                        "cursor": "#429037",
-                        "selection": "#42903733",
-                        "background": "#429037"
-                    },
-                    {
-                        "cursor": "#298fa6",
-                        "selection": "#298fa633",
-                        "background": "#298fa6"
+                        "cursor": "#7c3ed4",
+                        "selection": "#7c3ed433",
+                        "background": "#7c3ed4"
                     },
                     {
                         "cursor": "#6a7cdf",
@@ -192,9 +172,29 @@
                         "background": "#6a7cdf"
                     },
                     {
-                        "cursor": "#7c3ed4",
-                        "selection": "#7c3ed433",
-                        "background": "#7c3ed4"
+                        "cursor": "#298fa6",
+                        "selection": "#298fa633",
+                        "background": "#298fa6"
+                    },
+                    {
+                        "cursor": "#429037",
+                        "selection": "#42903733",
+                        "background": "#429037"
+                    },
+                    {
+                        "cursor": "#c1822c",
+                        "selection": "#c1822c33",
+                        "background": "#c1822c"
+                    },
+                    {
+                        "cursor": "#da601e",
+                        "selection": "#da601e33",
+                        "background": "#da601e"
+                    },
+                    {
+                        "cursor": "#b71c43",
+                        "selection": "#b71c4333",
+                        "background": "#b71c43"
                     }
                 ],
                 "syntax": {
@@ -855,29 +855,9 @@
                         "background": "#f2d5cf"
                     },
                     {
-                        "cursor": "#e1929b",
-                        "selection": "#e1929b33",
-                        "background": "#e1929b"
-                    },
-                    {
-                        "cursor": "#e7a98f",
-                        "selection": "#e7a98f33",
-                        "background": "#e7a98f"
-                    },
-                    {
-                        "cursor": "#dfcaa4",
-                        "selection": "#dfcaa433",
-                        "background": "#dfcaa4"
-                    },
-                    {
-                        "cursor": "#add19f",
-                        "selection": "#add19f33",
-                        "background": "#add19f"
-                    },
-                    {
-                        "cursor": "#92c4e1",
-                        "selection": "#92c4e133",
-                        "background": "#92c4e1"
+                        "cursor": "#caa8e9",
+                        "selection": "#caa8e933",
+                        "background": "#caa8e9"
                     },
                     {
                         "cursor": "#bdc0f2",
@@ -885,9 +865,29 @@
                         "background": "#bdc0f2"
                     },
                     {
-                        "cursor": "#caa8e9",
-                        "selection": "#caa8e933",
-                        "background": "#caa8e9"
+                        "cursor": "#92c4e1",
+                        "selection": "#92c4e133",
+                        "background": "#92c4e1"
+                    },
+                    {
+                        "cursor": "#add19f",
+                        "selection": "#add19f33",
+                        "background": "#add19f"
+                    },
+                    {
+                        "cursor": "#dfcaa4",
+                        "selection": "#dfcaa433",
+                        "background": "#dfcaa4"
+                    },
+                    {
+                        "cursor": "#e7a98f",
+                        "selection": "#e7a98f33",
+                        "background": "#e7a98f"
+                    },
+                    {
+                        "cursor": "#e1929b",
+                        "selection": "#e1929b33",
+                        "background": "#e1929b"
                     }
                 ],
                 "syntax": {
@@ -1548,29 +1548,9 @@
                         "background": "#f4dbd6"
                     },
                     {
-                        "cursor": "#e696a9",
-                        "selection": "#e696a933",
-                        "background": "#e696a9"
-                    },
-                    {
-                        "cursor": "#ecb197",
-                        "selection": "#ecb19733",
-                        "background": "#ecb197"
-                    },
-                    {
-                        "cursor": "#e6d4b0",
-                        "selection": "#e6d4b033",
-                        "background": "#e6d4b0"
-                    },
-                    {
-                        "cursor": "#add8a8",
-                        "selection": "#add8a833",
-                        "background": "#add8a8"
-                    },
-                    {
-                        "cursor": "#8cc7e7",
-                        "selection": "#8cc7e733",
-                        "background": "#8cc7e7"
+                        "cursor": "#c6aaf6",
+                        "selection": "#c6aaf633",
+                        "background": "#c6aaf6"
                     },
                     {
                         "cursor": "#bac1f7",
@@ -1578,9 +1558,29 @@
                         "background": "#bac1f7"
                     },
                     {
-                        "cursor": "#c6aaf6",
-                        "selection": "#c6aaf633",
-                        "background": "#c6aaf6"
+                        "cursor": "#8cc7e7",
+                        "selection": "#8cc7e733",
+                        "background": "#8cc7e7"
+                    },
+                    {
+                        "cursor": "#add8a8",
+                        "selection": "#add8a833",
+                        "background": "#add8a8"
+                    },
+                    {
+                        "cursor": "#e6d4b0",
+                        "selection": "#e6d4b033",
+                        "background": "#e6d4b0"
+                    },
+                    {
+                        "cursor": "#ecb197",
+                        "selection": "#ecb19733",
+                        "background": "#ecb197"
+                    },
+                    {
+                        "cursor": "#e696a9",
+                        "selection": "#e696a933",
+                        "background": "#e696a9"
                     }
                 ],
                 "syntax": {
@@ -2241,29 +2241,9 @@
                         "background": "#f5e0dc"
                     },
                     {
-                        "cursor": "#eb9ab7",
-                        "selection": "#eb9ab733",
-                        "background": "#eb9ab7"
-                    },
-                    {
-                        "cursor": "#f1ba9d",
-                        "selection": "#f1ba9d33",
-                        "background": "#f1ba9d"
-                    },
-                    {
-                        "cursor": "#f0e0bd",
-                        "selection": "#f0e0bd33",
-                        "background": "#f0e0bd"
-                    },
-                    {
-                        "cursor": "#aee1b2",
-                        "selection": "#aee1b233",
-                        "background": "#aee1b2"
-                    },
-                    {
-                        "cursor": "#86caee",
-                        "selection": "#86caee33",
-                        "background": "#86caee"
+                        "cursor": "#cbb0f7",
+                        "selection": "#cbb0f733",
+                        "background": "#cbb0f7"
                     },
                     {
                         "cursor": "#b9c3fc",
@@ -2271,9 +2251,29 @@
                         "background": "#b9c3fc"
                     },
                     {
-                        "cursor": "#cbb0f7",
-                        "selection": "#cbb0f733",
-                        "background": "#cbb0f7"
+                        "cursor": "#86caee",
+                        "selection": "#86caee33",
+                        "background": "#86caee"
+                    },
+                    {
+                        "cursor": "#aee1b2",
+                        "selection": "#aee1b233",
+                        "background": "#aee1b2"
+                    },
+                    {
+                        "cursor": "#f0e0bd",
+                        "selection": "#f0e0bd33",
+                        "background": "#f0e0bd"
+                    },
+                    {
+                        "cursor": "#f1ba9d",
+                        "selection": "#f1ba9d33",
+                        "background": "#f1ba9d"
+                    },
+                    {
+                        "cursor": "#eb9ab7",
+                        "selection": "#eb9ab733",
+                        "background": "#eb9ab7"
                     }
                 ],
                 "syntax": {

--- a/zed.tera
+++ b/zed.tera
@@ -31,7 +31,7 @@ whiskers:
                 "accents": [
                 {#- NOTE: not Catppuccin accents, but for indent_aware coloring #}
                 {%- for color in rainbow | reverse %}
-                    "#{{ color.hex }}ff"{%- if not loop.last %},{% endif -%}
+                    "#{{ color | mod(opacity=0.4) | get(key="hex") }}"{%- if not loop.last %},{% endif -%}
                 {% endfor %}
                 ],
                 "background.appearance": "opaque", {#- all others remove app window shadow-backdrop on macOS #}

--- a/zed.tera
+++ b/zed.tera
@@ -185,7 +185,7 @@ whiskers:
                         "selection": "#{{ c.surface2 | mod(opacity=0.5) | get(key="hex") }}",
                         "background": "#{{ c.rosewater.hex }}"
                     },
-                    {%- for color in rainbow %}
+                    {%- for color in rainbow | reverse %}
                     {
                         "cursor": "#{{ color.hex }}",
                         "selection": "#{{ color | mod(opacity=0.2) | get(key="hex") }}",

--- a/zed.tera
+++ b/zed.tera
@@ -30,7 +30,7 @@ whiskers:
             "style": {
                 "accents": [
                 {#- NOTE: not Catppuccin accents, but for indent_aware coloring #}
-                {%- for color in rainbow %}
+                {%- for color in rainbow | reverse %}
                     "#{{ color.hex }}ff"{%- if not loop.last %},{% endif -%}
                 {% endfor %}
                 ],


### PR DESCRIPTION
`rosewater` cursor color sometimes conflicts with `indent_aware` coloring in the first couple of indents.

before
<img width="231" alt="image" src="https://github.com/user-attachments/assets/bfa68c00-af8d-432d-bbf6-ed8d7fd46779" />

after:
<img width="233" alt="image" src="https://github.com/user-attachments/assets/0fbced9c-ba68-4e9d-9bd0-dc3e057fd588" />