### PR TITLE
feat(syntax): update variable.special to red

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -229,7 +229,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#ea76cb",
+                        "color": "#d20f39",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -932,7 +932,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f4b8e4",
+                        "color": "#e78284",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -1635,7 +1635,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f5bde6",
+                        "color": "#ed8796",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -2338,7 +2338,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f5c2e7",
+                        "color": "#f38ba8",
                         "font_style": "italic",
                         "font_weight": null
                     },

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -229,7 +229,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#ea76cb",
+                        "color": "#d20f39",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -932,7 +932,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f4b8e4",
+                        "color": "#e78284",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1635,7 +1635,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f5bde6",
+                        "color": "#ed8796",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -2338,7 +2338,7 @@
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#f5c2e7",
+                        "color": "#f38ba8",
                         "font_style": null,
                         "font_weight": null
                     },

--- a/zed.tera
+++ b/zed.tera
@@ -227,7 +227,7 @@ whiskers:
                         "font_weight": null
                     },
                     "variable.special": {
-                        "color": "#{{ c.pink.hex }}",
+                        "color": "#{{ c.red.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null
                     },


### PR DESCRIPTION
closes #88

changes all syntax instances of `variable.special` to be Red, before this was colored Pink

<details>

<summary>before</summary>

![55384](https://github.com/user-attachments/assets/5496b354-3299-49f6-bf96-d0ea40fed8b8)
![33177](https://github.com/user-attachments/assets/a5ac07df-4cb8-463a-85d5-2878862cf87a)
![48357](https://github.com/user-attachments/assets/fd4b70cf-32ac-4555-9c4f-da307a513967)

</details>

<details>

<summary>after</summary>

![40478](https://github.com/user-attachments/assets/0b2c1f22-40d5-45f6-b45c-d0cf19381533)
![44497](https://github.com/user-attachments/assets/d44ed676-cc69-4b79-a303-0166c1c19381)
![22885](https://github.com/user-attachments/assets/068b5679-4899-4bee-974f-df8c7991bc13)

</details>