### PR TITLE
fix(syntax): correct `link_text` and `link_uri`

### DIFF
--- a/zed.tera
+++ b/zed.tera
@@ -670,12 +670,12 @@ whiskers:
                         "font_weight": null
                     },
                     "link_text": {
-                        "color": "#{{ c.blue.hex }}",
+                        "color": "#{{ c.lavender.hex }}",
                         "font_style": null,
                         "font_weight": null
                     },
                     "link_uri": {
-                        "color": "#{{ c.rosewater.hex }}",
+                        "color": "#{{ c.blue.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null
                     },


### PR DESCRIPTION
| Zed (before this change) | VSCode |
| --- | --- |
| ![CleanShot 2025-04-08 at 07 38 11](https://github.com/user-attachments/assets/5ffb471d-179e-47f3-ad59-25663eb71742) | ![CleanShot 2025-04-08 at 07 38 04](https://github.com/user-attachments/assets/6fea2b89-4a4b-475e-80f3-a7c37c9adc84) |

This change aligns Zed's highlighting of URLs in markup to match our other editors.