### PR TITLE
fix: adjust contrast for inlay hints and inline git text

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -135,7 +135,7 @@
                 "hidden": "#9ca0b0",
                 "hidden.border": "#9ca0b0",
                 "hidden.background": "#e6e9ef",
-                "hint": "#81879d",
+                "hint": "#acb0be",
                 "hint.border": "#acb0be",
                 "hint.background": "#e6e9ef",
                 "ignored": "#9ca0b0",
@@ -658,8 +658,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#acb0be",
+                        "color": "#8c8fa1",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -848,7 +849,7 @@
                 "hidden": "#737994",
                 "hidden.border": "#737994",
                 "hidden.background": "#292c3c",
-                "hint": "#898fa5",
+                "hint": "#626880",
                 "hint.border": "#626880",
                 "hint.background": "#292c3c",
                 "ignored": "#737994",
@@ -1371,8 +1372,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#626880",
+                        "color": "#838ba7",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -1561,7 +1563,7 @@
                 "hidden": "#6e738d",
                 "hidden.border": "#6e738d",
                 "hidden.background": "#1e2030",
-                "hint": "#81869f",
+                "hint": "#5b6078",
                 "hint.border": "#5b6078",
                 "hint.background": "#1e2030",
                 "ignored": "#6e738d",
@@ -2084,8 +2086,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#5b6078",
+                        "color": "#8087a2",
                         "font_style": "italic",
                         "font_weight": null
                     },
@@ -2274,7 +2277,7 @@
                 "hidden": "#6c7086",
                 "hidden.border": "#6c7086",
                 "hidden.background": "#181825",
-                "hint": "#7c7f98",
+                "hint": "#585b70",
                 "hint.border": "#585b70",
                 "hint.background": "#181825",
                 "ignored": "#6c7086",
@@ -2797,8 +2800,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#585b70",
+                        "color": "#7f849c",
                         "font_style": "italic",
                         "font_weight": null
                     },

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -135,7 +135,7 @@
                 "hidden": "#9ca0b0",
                 "hidden.border": "#9ca0b0",
                 "hidden.background": "#e6e9ef",
-                "hint": "#81879d",
+                "hint": "#acb0be",
                 "hint.border": "#acb0be",
                 "hint.background": "#e6e9ef",
                 "ignored": "#9ca0b0",
@@ -658,8 +658,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#acb0be",
+                        "color": "#8c8fa1",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -848,7 +849,7 @@
                 "hidden": "#737994",
                 "hidden.border": "#737994",
                 "hidden.background": "#292c3c",
-                "hint": "#898fa5",
+                "hint": "#626880",
                 "hint.border": "#626880",
                 "hint.background": "#292c3c",
                 "ignored": "#737994",
@@ -1371,8 +1372,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#626880",
+                        "color": "#838ba7",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1561,7 +1563,7 @@
                 "hidden": "#6e738d",
                 "hidden.border": "#6e738d",
                 "hidden.background": "#1e2030",
-                "hint": "#81869f",
+                "hint": "#5b6078",
                 "hint.border": "#5b6078",
                 "hint.background": "#1e2030",
                 "ignored": "#6e738d",
@@ -2084,8 +2086,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#5b6078",
+                        "color": "#8087a2",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -2274,7 +2277,7 @@
                 "hidden": "#6c7086",
                 "hidden.border": "#6c7086",
                 "hidden.background": "#181825",
-                "hint": "#7c7f98",
+                "hint": "#585b70",
                 "hint.border": "#585b70",
                 "hint.background": "#181825",
                 "ignored": "#6c7086",
@@ -2797,8 +2800,9 @@
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "#585b70",
+                        "color": "#7f849c",
                         "font_style": null,
                         "font_weight": null
                     },

--- a/zed.tera
+++ b/zed.tera
@@ -161,8 +161,9 @@ whiskers:
                 "hidden": "{{ c.overlay0.hex }}",
                 "hidden.border": "{{ c.overlay0.hex }}",
                 "hidden.background": "{{ c.mantle.hex }}",
-                {#- NOTE: this affects inline git text AND inlay hints #}
-                "hint": {% if flavor.dark %}"{{ c.surface2 | add(lightness=15) | get(key="hex") }}"{% else %}"{{ c.surface2 | sub(lightness=15) | get(key="hex") }}"{%- endif -%},
+                {#- NOTE: this affects inline git text #}
+                "hint": "{{ c.surface2.hex }}",
+                {#- NOTE: affect inlay hints bg #}
                 "hint.border": "{{ c.surface2.hex }}",
                 "hint.background": "{{ c.mantle.hex }}",
                 "ignored": "{{ c.overlay0.hex }}",
@@ -676,8 +677,9 @@ whiskers:
                         "font_style": null,
                         "font_weight": 700
                     },
+
                     "hint": {
-                        "color": "{{ c.surface2.hex }}",
+                        "color": "{{ c.overlay1.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null
                     },


### PR DESCRIPTION
inline git text and inlay hints color relation were fixed as some point, so each can now be colored separately. 

inlay hints before:
<img width="808" height="338" alt="image" src="https://github.com/user-attachments/assets/8589645e-9de4-4002-87a1-b5cd99e8ee6b" />

inlay hints after:
<img width="797" height="340" alt="image" src="https://github.com/user-attachments/assets/bfaa2aa0-bf28-4b38-a5e6-a0809c8576c1" />


closes #116 

inline git before:

<img width="615" height="84" alt="image" src="https://github.com/user-attachments/assets/351b12b6-c072-4c02-9e73-c5c362d8d80c" />


<img width="586" height="83" alt="image" src="https://github.com/user-attachments/assets/d5bf82e0-05e9-4b45-bff6-65100bef7eaa" />


inline git after:

<img width="611" height="83" alt="image" src="https://github.com/user-attachments/assets/273b96e7-4cdc-4298-b9ec-7ca65e62d213" />


<img width="602" height="81" alt="image" src="https://github.com/user-attachments/assets/888a1cdb-c7bf-4f26-ae00-2e8cc5b0cdaf" />
