### PR TITLE
feat: markdown title high contrast

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -710,7 +710,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#4c4f69",
+                        "color": "#7287fd",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -1429,7 +1429,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#c6d0f5",
+                        "color": "#babbf1",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -2148,7 +2148,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#cad3f5",
+                        "color": "#b7bdf8",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -2867,7 +2867,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#cdd6f4",
+                        "color": "#b4befe",
                         "font_style": null,
                         "font_weight": 800
                     },

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -710,7 +710,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#4c4f69",
+                        "color": "#7287fd",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -1429,7 +1429,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#c6d0f5",
+                        "color": "#babbf1",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -2148,7 +2148,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#cad3f5",
+                        "color": "#b7bdf8",
                         "font_style": null,
                         "font_weight": 800
                     },
@@ -2867,7 +2867,7 @@
                       "font_weight": null
                     },
                     "title": {
-                        "color": "#cdd6f4",
+                        "color": "#b4befe",
                         "font_style": null,
                         "font_weight": 800
                     },

--- a/zed.tera
+++ b/zed.tera
@@ -763,7 +763,7 @@ whiskers:
                       "font_weight": null
                     },
                     "title": {
-                        "color": "{{ c.text.hex }}",
+                        "color": "{{ c.lavender.hex }}",
                         "font_style": null,
                         "font_weight": 800
                     },


### PR DESCRIPTION
current title's color is the same as text , I think need some color for it 

from 
<img width="2446" height="1262" alt="image" src="https://github.com/user-attachments/assets/f4e9d04d-7c65-4f20-95b8-1ba3e48f900a" />

to 

<img width="2020" height="1466" alt="image" src="https://github.com/user-attachments/assets/48529662-1a54-4c5a-bb36-2dd784aed34d" />
