### PR TITLE
feat: support zed comments.info comments.warn

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -538,12 +538,22 @@
                         "font_style": "italic",
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#179299",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#d20f39",
                         "font_style": "italic",
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#df8e1d",
                         "font_style": "italic",
                         "font_weight": null
@@ -1257,12 +1267,22 @@
                         "font_style": "italic",
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#81c8be",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#e78284",
                         "font_style": "italic",
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#e5c890",
                         "font_style": "italic",
                         "font_weight": null
@@ -1976,12 +1996,22 @@
                         "font_style": "italic",
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#8bd5ca",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#ed8796",
                         "font_style": "italic",
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#eed49f",
                         "font_style": "italic",
                         "font_weight": null
@@ -2695,12 +2725,22 @@
                         "font_style": "italic",
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#94e2d5",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#f38ba8",
                         "font_style": "italic",
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#f9e2af",
                         "font_style": "italic",
                         "font_weight": null

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -538,12 +538,22 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#d20f39",
                         "font_style": null,
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#df8e1d",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#df8e1d",
                         "font_style": null,
                         "font_weight": null
@@ -1257,12 +1267,22 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#e78284",
                         "font_style": null,
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#e5c890",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#e5c890",
                         "font_style": null,
                         "font_weight": null
@@ -1976,12 +1996,22 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#ed8796",
                         "font_style": null,
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#eed49f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#eed49f",
                         "font_style": null,
                         "font_weight": null
@@ -2695,12 +2725,22 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "comment.info": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "#f38ba8",
                         "font_style": null,
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "#f9e2af",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "#f9e2af",
                         "font_style": null,
                         "font_weight": null

--- a/zed.tera
+++ b/zed.tera
@@ -582,12 +582,22 @@ whiskers:
                         "font_weight": null
                     },
                     {#- ! untested, rollback if Zed supports these #}
+                    "comment.info": {
+                        "color": "{{ c.teal.hex }}",
+                        "font_style": {{ italics }},
+                        "font_weight": null
+                    },
                     "comment.error": {
                         "color": "{{ c.red.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null
                     },
                     "comment.warning": {
+                        "color": "{{ c.yellow.hex }}",
+                        "font_style": {{ italics }},
+                        "font_weight": null
+                    },
+                    "comment.warn": {
                         "color": "{{ c.yellow.hex }}",
                         "font_style": {{ italics }},
                         "font_weight": null


### PR DESCRIPTION
according to https://github.com/thedadams/zed-comment/blob/main/languages/comment/highlights.scm
zed comments has 

- comments.todo - repo already has 
- comments.info. --- repo not yet
- comments.warn  -- repo has 'warning', but no 'warn'
- comments.error  --- repo already has 

from 

<img width="1342" height="1516" alt="image" src="https://github.com/user-attachments/assets/517ede65-3f89-4cc3-a591-f3f0d224cc49" />

to

<img width="1006" height="1436" alt="image" src="https://github.com/user-attachments/assets/0bf8f346-a16a-4462-bf60-a089cbfe46b1" />

test file content
```ts
// comments.todo
// TODO: dd
// WIP: dd
// MAYBE: dd
// QUESTION: dd

// comments.info
// NOTE: ddd
// XXX : ddd
// INFO: ddd
// DOCS: ddd
// PERF: ddd
// TEST: ddd

// comments.warn
// WARN: ddd
// HACK: ddd
// WARNING: ddd
// FIX: ddd
// SAFETY: ddd

// comments.error
// FIXME: dd
// BUG: dd
// ERROR: dd
// DELETE: dd

```
it will resolve https://github.com/catppuccin/zed/issues/130