### PR TITLE
fix: type color not working

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -338,6 +338,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#df8e1d",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#df8e1d",
                         "font_style": null,
@@ -570,21 +585,6 @@
                     },
                     "diff.minus": {
                         "color": "#d20f39",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#1e66f5",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#df8e1d",
-                        "font_style": "italic",
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#179299",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1057,6 +1057,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#e5c890",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#e5c890",
                         "font_style": null,
@@ -1289,21 +1304,6 @@
                     },
                     "diff.minus": {
                         "color": "#e78284",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#8caaee",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#e5c890",
-                        "font_style": "italic",
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#81c8be",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1776,6 +1776,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#eed49f",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#eed49f",
                         "font_style": null,
@@ -2008,21 +2023,6 @@
                     },
                     "diff.minus": {
                         "color": "#ed8796",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#8aadf4",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#eed49f",
-                        "font_style": "italic",
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#8bd5ca",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -2495,6 +2495,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#f9e2af",
+                        "font_style": "italic",
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#f9e2af",
                         "font_style": null,
@@ -2727,21 +2742,6 @@
                     },
                     "diff.minus": {
                         "color": "#f38ba8",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#89b4fa",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#f9e2af",
-                        "font_style": "italic",
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#94e2d5",
                         "font_style": null,
                         "font_weight": null
                     },

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -338,6 +338,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#1e66f5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#df8e1d",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#179299",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#df8e1d",
                         "font_style": null,
@@ -570,21 +585,6 @@
                     },
                     "diff.minus": {
                         "color": "#d20f39",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#1e66f5",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#df8e1d",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#179299",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1057,6 +1057,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#8caaee",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#e5c890",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#81c8be",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#e5c890",
                         "font_style": null,
@@ -1289,21 +1304,6 @@
                     },
                     "diff.minus": {
                         "color": "#e78284",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#8caaee",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#e5c890",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#81c8be",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -1776,6 +1776,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#8aadf4",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#eed49f",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#8bd5ca",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#eed49f",
                         "font_style": null,
@@ -2008,21 +2023,6 @@
                     },
                     "diff.minus": {
                         "color": "#ed8796",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#8aadf4",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#eed49f",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#8bd5ca",
                         "font_style": null,
                         "font_weight": null
                     },
@@ -2495,6 +2495,21 @@
                         "font_style": null,
                         "font_weight": null
                     },
+                    "tag": {
+                        "color": "#89b4fa",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "#f9e2af",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "#94e2d5",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     "type": {
                         "color": "#f9e2af",
                         "font_style": null,
@@ -2727,21 +2742,6 @@
                     },
                     "diff.minus": {
                         "color": "#f38ba8",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag": {
-                        "color": "#89b4fa",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "#f9e2af",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "#94e2d5",
                         "font_style": null,
                         "font_weight": null
                     },

--- a/zed.tera
+++ b/zed.tera
@@ -375,6 +375,22 @@ whiskers:
                         "font_style": null,
                         "font_weight": null
                     },
+                    {#- Tags #}
+                    "tag": {
+                        "color": "{{ c.blue.hex }}",
+                        "font_style": null,
+                        "font_weight": null
+                    },
+                    "tag.attribute": {
+                        "color": "{{ c.yellow.hex }}",
+                        "font_style": {{ italics }},
+                        "font_weight": null
+                    },
+                    "tag.delimiter": {
+                        "color": "{{ c.teal.hex }}",
+                        "font_style": null,
+                        "font_weight": null
+                    },
                     {#- Types #}
                     "type": {
                         "color": "{{ c.yellow.hex }}",
@@ -619,22 +635,7 @@ whiskers:
                         "font_style": null,
                         "font_weight": null
                     },
-                    {#- Tags #}
-                    "tag": {
-                        "color": "{{ c.blue.hex }}",
-                        "font_style": null,
-                        "font_weight": null
-                    },
-                    "tag.attribute": {
-                        "color": "{{ c.yellow.hex }}",
-                        "font_style": {{ italics }},
-                        "font_weight": null
-                    },
-                    "tag.delimiter": {
-                        "color": "{{ c.teal.hex }}",
-                        "font_style": null,
-                        "font_weight": null
-                    },
+
                     {#- Misc #}
                     {#- Language specific (not supported) #}
                     {#- Legacy highlights #}


### PR DESCRIPTION
I noticed the "syntax.type" is not working in vue when use  cutppuccin theme

<img width="1646" height="1236" alt="image" src="https://github.com/user-attachments/assets/811176e7-559d-4803-bfb5-cf37cf940018" />

the default theme， look like this 

<img width="1832" height="1322" alt="image" src="https://github.com/user-attachments/assets/1887acdb-fc6d-459f-9d93-822ff4bb72b0" />

the tokyo night theme

<img width="1778" height="1388" alt="image" src="https://github.com/user-attachments/assets/2cdfb69c-b742-453b-aecd-ec54b4650596" />

I spent several hours diffing the files, but found that there wasn’t actually much difference in the configuration.
 I tried changing the order of "syntax.type" and "syntax.tag", and then it worked.

<img width="1864" height="1320" alt="image" src="https://github.com/user-attachments/assets/fa8fd84e-224b-4358-9eb0-fb192ca62b54" />


this is my test file `testing.vue`
```vue
<script setup lang="ts">
import TheWelcome from '@/components/TheWelcome.vue'
import { ref } from 'vue'
const good = ref('test-333')

// TODO: ddd
const test = ref(true)

if (test.value) {
}
</script>

<template>
  <main class="xx">
    <TheWelcome :show="true" :testProp="true" @update:show="() => {}" :class="[]">
      <img style="width: 100px; height: 100px" />
    </TheWelcome>
  </main>
</template>
<style lang="less">
.test {
  red: 'dd';
}
/* TODO: dd */
/* WARN: dd */
/* INFO: dd */
.body {
}
</style>

```
  