### PR TITLE
chore: bump version to v0.2.26

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "catppuccin"
 name = "Catppuccin"
 schema_version = 1
-version = "0.2.25"
+version = "0.2.26"
 authors = ["Catppuccin <releases@catppuccin.com>"]
 description = "🦀 Soothing pastel theme for Zed"
 repository = "https://github.com/catppuccin/zed"


### PR DESCRIPTION
Bump the Catppuccin extension to 0.2.26 to release the changes already merged since v0.2.25. The release will use the existing signed-tag recipe and GitHub-generated release notes.

Validation: generated all 28 JSON assets (112 themes), passed the full Whiskers consistency check and JSON validation, and confirmed regeneration leaves the tracked themes unchanged.
