### PR TITLE
fix(css): highlight pseudo-selectors in yellow

### DIFF
--- a/themes/catppuccin-mauve.json
+++ b/themes/catppuccin-mauve.json
@@ -392,6 +392,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "selector.pseudo": {
+            "color": "#df8e1d",
+            "font_style": null,
+            "font_weight": null
+          },
           "property": {
             "color": "#7287fd",
             "font_style": null,
@@ -1130,6 +1135,11 @@
             "font_weight": null
           },
           "attribute": {
+            "color": "#e5c890",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
             "color": "#e5c890",
             "font_style": null,
             "font_weight": null
@@ -1876,6 +1886,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "selector.pseudo": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
           "property": {
             "color": "#b7bdf8",
             "font_style": null,
@@ -2614,6 +2629,11 @@
             "font_weight": null
           },
           "attribute": {
+            "color": "#f9e2af",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
             "color": "#f9e2af",
             "font_style": null,
             "font_weight": null

--- a/themes/catppuccin-no-italics-mauve.json
+++ b/themes/catppuccin-no-italics-mauve.json
@@ -392,6 +392,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "selector.pseudo": {
+            "color": "#df8e1d",
+            "font_style": null,
+            "font_weight": null
+          },
           "property": {
             "color": "#7287fd",
             "font_style": null,
@@ -1130,6 +1135,11 @@
             "font_weight": null
           },
           "attribute": {
+            "color": "#e5c890",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
             "color": "#e5c890",
             "font_style": null,
             "font_weight": null
@@ -1876,6 +1886,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "selector.pseudo": {
+            "color": "#eed49f",
+            "font_style": null,
+            "font_weight": null
+          },
           "property": {
             "color": "#b7bdf8",
             "font_style": null,
@@ -2614,6 +2629,11 @@
             "font_weight": null
           },
           "attribute": {
+            "color": "#f9e2af",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector.pseudo": {
             "color": "#f9e2af",
             "font_style": null,
             "font_weight": null

--- a/zed.tera
+++ b/zed.tera
@@ -431,6 +431,11 @@ whiskers:
             "font_style": null,
             "font_weight": null
           },
+          "selector.pseudo": {
+            "color": "{{ c.yellow.hex }}",
+            "font_style": null,
+            "font_weight": null
+          },
           "property": {
             "color": "{{ c.lavender.hex }}",
             "font_style": null,


### PR DESCRIPTION
Colors CSS pseudo-elements yellow to distinguish them from tags and properties. Zed shares this capture with pseudo-classes, so both become yellow.

Fixes #103.

Verified in Zed 1.18.1 across all four flavors and blue/no-italics; generation and JSON checks pass.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/04732450-c93f-4f7a-ae47-bca140e3703b) | ![After](https://github.com/user-attachments/assets/462048a0-b227-4252-a2d7-33115df3217e) |
